### PR TITLE
Fixed c-code for picky compiler

### DIFF
--- a/Source/Firmware/dirscan.cpp
+++ b/Source/Firmware/dirscan.cpp
@@ -209,7 +209,7 @@ bool ListDirectoryContents( const char *sDir, REUDIRENTRY *d, u32 *n, u32 *nElem
 				nAdditionalEntries ++;
 			} else
 			{
-				if ( strstr( FileInfo.fname, ".reu" ) > 0 || strstr( FileInfo.fname, ".REU" ) > 0 )
+				if ( strstr( FileInfo.fname, ".reu" ) || strstr( FileInfo.fname, ".REU" ) )
 				{
 					strcpy( (char*)sort[sortCur].path, sDir );
 					strcpy( (char*)sort[sortCur].filename, FileInfo.fname );
@@ -217,7 +217,7 @@ bool ListDirectoryContents( const char *sDir, REUDIRENTRY *d, u32 *n, u32 *nElem
 					sort[ sortCur++ ].f = REUDIR_REUIMAGE;
 					nAdditionalEntries ++;
 				}
-				if ( strstr( FileInfo.fname, ".georam" ) > 0 || strstr( FileInfo.fname, ".GEORAM" ) > 0 )
+				if ( strstr( FileInfo.fname, ".georam" ) || strstr( FileInfo.fname, ".GEORAM" ) )
 				{
 					strcpy( (char*)sort[sortCur].path, sDir );
 					strcpy( (char*)sort[sortCur].filename, FileInfo.fname );
@@ -225,7 +225,7 @@ bool ListDirectoryContents( const char *sDir, REUDIRENTRY *d, u32 *n, u32 *nElem
 					sort[ sortCur++ ].f = REUDIR_GEOIMAGE;
 					nAdditionalEntries ++;
 				}
-				if ( strstr( FileInfo.fname, ".prg" ) > 0 || strstr( FileInfo.fname, ".PRG" ) > 0 )
+				if ( strstr( FileInfo.fname, ".prg" ) || strstr( FileInfo.fname, ".PRG" ) )
 				{
 					strcpy( (char*)sort[sortCur].path, sDir );
 					strcpy( (char*)sort[sortCur].filename, FileInfo.fname );


### PR DESCRIPTION
Needed to fix for a successful RAD build with 
```
$ /opt/arm-gnu-toolchain-11.3.rel1-x86_64-aarch64-none-elf/bin/aarch64-none-elf-g++ --version
aarch64-none-elf-g++ (Arm GNU Toolchain 11.3.Rel1) 11.3.1 20220712
```